### PR TITLE
Add /api/health endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ A directory-first community portal for RaidGuild that centralizes profiles and c
 - `/modules/profile-generators` profile generators module
 - `/modules/skills-explorer` skills explorer module
 - `/api/modules` registry JSON
+- `/api/health` deploy/smoke health check (returns ok + git sha)
 - `/api/module-data` module data API
 - `/api/announcements` announcements API
 - `/api/cohorts` cohorts API

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,32 @@
+// Lightweight health endpoint for deploy readiness + smoke tests.
+// Avoid returning secrets. Safe to expose publicly.
+
+export const runtime = "nodejs";
+
+export async function GET() {
+  const now = new Date().toISOString();
+
+  // Vercel automatically provides these for Git deployments.
+  const sha =
+    process.env.VERCEL_GIT_COMMIT_SHA ||
+    process.env.NEXT_PUBLIC_VERCEL_GIT_COMMIT_SHA ||
+    null;
+  const ref = process.env.VERCEL_GIT_COMMIT_REF || null;
+  const repo = process.env.VERCEL_GIT_REPO_SLUG || null;
+  const env = process.env.VERCEL_ENV || process.env.NODE_ENV || null;
+
+  return Response.json(
+    {
+      ok: true,
+      now,
+      env,
+      git: { sha, ref, repo },
+    },
+    {
+      headers: {
+        // Encourage callers to bust caches; we want "current deploy" signal.
+        "cache-control": "no-store, max-age=0",
+      },
+    }
+  );
+}


### PR DESCRIPTION
Adds a lightweight /api/health endpoint (no-store) that returns ok + Vercel git metadata (sha/ref) for staging readiness checks and smoke tests.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new health check API endpoint that returns deployment status, timestamp, and Git metadata for smoke testing and health monitoring.

* **Documentation**
  * Updated README with information about the health check endpoint and its response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->