### PR TITLE
chore(stage-poller): log which staging seed failed

### DIFF
--- a/automation/stage-poller.mjs
+++ b/automation/stage-poller.mjs
@@ -253,7 +253,14 @@ async function applyStagingSeeds(fromRoot) {
     const full = path.join(stagingSeedsDir, file);
     const sql = await fs.readFile(full, "utf8");
     if (!sql.trim()) continue;
-    await dbExecMany(sql);
+
+    console.log(`Applying staging seed: ${file}`);
+    try {
+      await dbExecMany(sql);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(`Staging seed failed (${file}): ${msg}`);
+    }
   }
 }
 


### PR DESCRIPTION
Adds per-file logging and wraps errors in applyStagingSeeds() so staging failures identify the specific .sql file that caused the Postgres error.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting with more descriptive messages when staging operations fail, replacing silent failures with labeled error details.

* **Chores**
  * Enhanced logging visibility during staging processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->