### PR TITLE
chore(stage-poller): include SQL error position/snippet

### DIFF
--- a/automation/stage-poller.mjs
+++ b/automation/stage-poller.mjs
@@ -258,8 +258,23 @@ async function applyStagingSeeds(fromRoot) {
     try {
       await dbExecMany(sql);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      throw new Error(`Staging seed failed (${file}): ${msg}`);
+      const anyErr = /** @type {any} */ (err);
+      const baseMsg = err instanceof Error ? err.message : String(err);
+
+      // node-postgres sometimes provides a 1-indexed error position within the SQL string.
+      const posRaw = anyErr?.position;
+      const pos = typeof posRaw === "string" || typeof posRaw === "number" ? Number(posRaw) : null;
+
+      let context = "";
+      if (pos && Number.isFinite(pos) && pos > 0) {
+        const i = Math.max(0, pos - 1);
+        const start = Math.max(0, i - 60);
+        const end = Math.min(sql.length, i + 60);
+        const snippet = sql.slice(start, end).replace(/\s+/g, " ").trim();
+        context = ` (pos ${pos}; snippet: ${snippet})`;
+      }
+
+      throw new Error(`Staging seed failed (${file}): ${baseMsg}${context}`);
     }
   }
 }


### PR DESCRIPTION
When applying staging seed SQL, include Postgres error position and a small SQL snippet in the failure message (when available) to make syntax errors debuggable.