### PR TITLE
feat: module requests module

### DIFF
--- a/modules/registry.json
+++ b/modules/registry.json
@@ -469,9 +469,15 @@
       "type": "link",
       "url": "/modules/bounty-board",
       "status": "in-progress",
-      "owner": { "name": "Hosts", "contact": "discord:@hosts" },
+      "owner": {
+        "name": "Hosts",
+        "contact": "discord:@hosts"
+      },
       "requiresAuth": true,
-      "tags": ["people-tools", "me-tools"],
+      "tags": [
+        "people-tools",
+        "me-tools"
+      ],
       "presentation": {
         "mode": "page",
         "trigger": "button"
@@ -498,7 +504,11 @@
         "contact": "@skuhlmann"
       },
       "requiresAuth": true,
-      "tags": ["people-tools", "me-tools", "home"],
+      "tags": [
+        "people-tools",
+        "me-tools",
+        "home"
+      ],
       "presentation": {
         "mode": "page",
         "trigger": "button"
@@ -543,6 +553,28 @@
         "maxItems": 3,
         "showTitle": true,
         "imageKey": "Image"
+      }
+    },
+    {
+      "id": "module-requests",
+      "title": "Module Requests",
+      "description": "Propose new portal modules and signal interest.",
+      "lane": "portal",
+      "type": "link",
+      "url": "/modules/module-requests",
+      "status": "beta",
+      "owner": {
+        "name": "Portal Core",
+        "contact": "discord:@portal"
+      },
+      "requiresAuth": true,
+      "tags": [
+        "me-tools"
+      ],
+      "presentation": {
+        "mode": "page",
+        "trigger": "button",
+        "layout": "wide"
       }
     }
   ]

--- a/src/app/api/modules/module-requests/[id]/promote/route.ts
+++ b/src/app/api/modules/module-requests/[id]/promote/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from "next/server";
+import { requireHost } from "../../_auth";
+import { toGitHubIssueMarkdown, type ModuleRequestSpec } from "../../lib";
+
+type PromoteBody = {
+  github_issue_url?: string;
+};
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireHost(request);
+  if ("error" in auth) {
+    return Response.json({ error: auth.error }, { status: auth.status ?? 400 });
+  }
+
+  const { id } = await params;
+  const admin = auth.admin;
+
+  let body: PromoteBody = {};
+  try {
+    body = (await request.json()) as PromoteBody;
+  } catch {
+    // ok
+  }
+
+  const { data, error } = await admin
+    .from("module_requests")
+    .select(
+      "id, module_id, title, owner_contact, status, spec, github_issue_url, votes_count, promotion_threshold, submitted_to_github_at",
+    )
+    .eq("id", id)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+  if (!data) {
+    return Response.json({ error: "Not found." }, { status: 404 });
+  }
+
+  if (!(data.status === "ready" || data.status === "open")) {
+    return Response.json({ error: "Only open/ready requests can be promoted." }, { status: 400 });
+  }
+
+  const markdown = toGitHubIssueMarkdown({
+    title: data.title,
+    moduleId: data.module_id,
+    ownerContact: data.owner_contact,
+    spec: (data.spec ?? {}) as ModuleRequestSpec,
+  });
+
+  const githubUrl = typeof body.github_issue_url === "string" ? body.github_issue_url.trim() : "";
+
+  if (githubUrl) {
+    const { data: updated, error: updateError } = await admin
+      .from("module_requests")
+      .update({
+        github_issue_url: githubUrl,
+        submitted_to_github_at: new Date().toISOString(),
+        status: "submitted_to_github",
+      })
+      .eq("id", id)
+      .select(
+        "id, created_by, module_id, title, owner_contact, status, spec, votes_count, promotion_threshold, github_issue_url, submitted_to_github_at, created_at, updated_at",
+      )
+      .single();
+
+    if (updateError) {
+      return Response.json({ error: updateError.message }, { status: 500 });
+    }
+
+    return Response.json({ item: updated, markdown });
+  }
+
+  return Response.json({ markdown, item: data });
+}

--- a/src/app/api/modules/module-requests/[id]/publish/route.ts
+++ b/src/app/api/modules/module-requests/[id]/publish/route.ts
@@ -1,0 +1,75 @@
+import { NextRequest } from "next/server";
+import { requireAuth } from "../../_auth";
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth(request);
+  if ("error" in auth) {
+    return Response.json({ error: auth.error }, { status: auth.status ?? 400 });
+  }
+
+  const { id } = await params;
+  const admin = auth.admin;
+
+  const { data: existing, error: existingError } = await admin
+    .from("module_requests")
+    .select("id, created_by, status, title, module_id, spec")
+    .eq("id", id)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (existingError) {
+    return Response.json({ error: existingError.message }, { status: 500 });
+  }
+  if (!existing) {
+    return Response.json({ error: "Not found." }, { status: 404 });
+  }
+  if (existing.created_by !== auth.userId) {
+    return Response.json({ error: "Only the creator can publish." }, { status: 403 });
+  }
+  if (existing.status !== "draft") {
+    return Response.json({ error: "Only draft requests can be published." }, { status: 400 });
+  }
+
+  const spec = existing.spec as Json;
+  const getField = (key: string) => {
+    if (!spec || typeof spec !== "object" || Array.isArray(spec)) return "";
+    const record = spec as Record<string, Json | undefined>;
+    return typeof record[key] === "string" ? record[key].trim() : "";
+  };
+
+  const required = [
+    ["problem", getField("problem")],
+    ["scope", getField("scope")],
+    ["ux", getField("ux")],
+  ] as const;
+  const missing = required
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (!existing.title?.trim() || !existing.module_id?.trim() || missing.length) {
+    return Response.json(
+      {
+        error: `Missing required fields: title/module_id and ${missing.join(", ")}.`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const { data, error } = await admin
+    .from("module_requests")
+    .update({ status: "open" })
+    .eq("id", id)
+    .select(
+      "id, created_by, module_id, title, owner_contact, status, spec, votes_count, promotion_threshold, github_issue_url, submitted_to_github_at, created_at, updated_at",
+    )
+    .single();
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+
+  return Response.json({ item: data });
+}

--- a/src/app/api/modules/module-requests/[id]/route.ts
+++ b/src/app/api/modules/module-requests/[id]/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest } from "next/server";
+import type { TablesUpdate } from "@/lib/types/db";
+import { requireAuth } from "../_auth";
+import type { ModuleRequestSpec } from "../lib";
+import type { ModuleRequestSpec } from "../lib";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth(request);
+  if ("error" in auth) {
+    return Response.json({ error: auth.error }, { status: auth.status ?? 400 });
+  }
+
+  const { id } = await params;
+  const admin = auth.admin;
+
+  const { data, error } = await admin
+    .from("module_requests")
+    .select(
+      "id, created_by, module_id, title, owner_contact, status, spec, votes_count, promotion_threshold, github_issue_url, submitted_to_github_at, created_at, updated_at",
+    )
+    .eq("id", id)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+  if (!data) {
+    return Response.json({ error: "Not found." }, { status: 404 });
+  }
+
+  const { data: voteRow } = await admin
+    .from("module_request_votes")
+    .select("request_id")
+    .eq("request_id", id)
+    .eq("user_id", auth.userId)
+    .maybeSingle();
+
+  return Response.json({ item: { ...data, viewer_has_voted: Boolean(voteRow) } });
+}
+
+type PatchBody = {
+  title?: string;
+  module_id?: string;
+  owner_contact?: string | null;
+  spec?: ModuleRequestSpec;
+};
+
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth(request);
+  if ("error" in auth) {
+    return Response.json({ error: auth.error }, { status: auth.status ?? 400 });
+  }
+
+  const { id } = await params;
+
+  let body: PatchBody;
+  try {
+    body = (await request.json()) as PatchBody;
+  } catch {
+    return Response.json({ error: "Invalid JSON." }, { status: 400 });
+  }
+
+  const admin = auth.admin;
+
+  // Ensure the viewer can edit (creator + draft)
+  const { data: existing, error: existingError } = await admin
+    .from("module_requests")
+    .select("id, created_by, status")
+    .eq("id", id)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (existingError) {
+    return Response.json({ error: existingError.message }, { status: 500 });
+  }
+  if (!existing) {
+    return Response.json({ error: "Not found." }, { status: 404 });
+  }
+  if (existing.created_by !== auth.userId) {
+    return Response.json({ error: "Only the creator can edit this request." }, { status: 403 });
+  }
+  if (existing.status !== "draft") {
+    return Response.json({ error: "Only draft requests can be edited." }, { status: 403 });
+  }
+
+  const update: TablesUpdate<"module_requests"> = {};
+  if (typeof body.title === "string") {
+    const title = body.title.trim();
+    if (!title) {
+      return Response.json({ error: "Title is required." }, { status: 400 });
+    }
+    update.title = title;
+  }
+  if (typeof body.module_id === "string") {
+    const moduleId = body.module_id.trim();
+    if (!moduleId) {
+      return Response.json({ error: "module_id is required." }, { status: 400 });
+    }
+    update.module_id = moduleId;
+  }
+  if (body.owner_contact === null) {
+    update.owner_contact = null;
+  } else if (typeof body.owner_contact === "string") {
+    update.owner_contact = body.owner_contact.trim() || null;
+  }
+  if (body.spec && typeof body.spec === "object") {
+    update.spec = body.spec as ModuleRequestSpec;
+  }
+
+  const { data, error } = await admin
+    .from("module_requests")
+    .update(update)
+    .eq("id", id)
+    .select(
+      "id, created_by, module_id, title, owner_contact, status, spec, votes_count, promotion_threshold, github_issue_url, submitted_to_github_at, created_at, updated_at",
+    )
+    .single();
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+
+  return Response.json({ item: data });
+}

--- a/src/app/api/modules/module-requests/[id]/vote/route.ts
+++ b/src/app/api/modules/module-requests/[id]/vote/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest } from "next/server";
+import type { PostgrestError } from "@supabase/supabase-js";
+import { supabaseAdminClient } from "@/lib/supabase/admin";
+import { requireAuth } from "../../_auth";
+
+type AdminClient = ReturnType<typeof supabaseAdminClient>;
+
+async function loadRequest(admin: AdminClient, id: string) {
+  const { data, error } = await admin
+    .from("module_requests")
+    .select(
+      "id, created_by, module_id, title, owner_contact, status, spec, votes_count, promotion_threshold, github_issue_url, submitted_to_github_at, created_at, updated_at",
+    )
+    .eq("id", id)
+    .is("deleted_at", null)
+    .maybeSingle();
+
+  if (error) throw new Error(error.message);
+  return data ?? null;
+}
+
+function isUniqueViolation(error: PostgrestError): boolean {
+  return error.code === "23505";
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth(request);
+  if ("error" in auth) {
+    return Response.json({ error: auth.error }, { status: auth.status ?? 400 });
+  }
+
+  const { id } = await params;
+  const admin = auth.admin;
+
+  const existing = await loadRequest(admin, id);
+  if (!existing) {
+    return Response.json({ error: "Not found." }, { status: 404 });
+  }
+  if (!(existing.status === "open" || existing.status === "ready")) {
+    return Response.json(
+      { error: "Voting is only allowed for open/ready requests." },
+      { status: 400 },
+    );
+  }
+
+  const { error } = await admin
+    .from("module_request_votes")
+    .insert({ request_id: id, user_id: auth.userId });
+
+  if (error) {
+    // Unique violation from composite PK
+    if (isUniqueViolation(error)) {
+      return Response.json({ error: "You have already voted." }, { status: 409 });
+    }
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+
+  const updated = await loadRequest(admin, id);
+  return Response.json({ item: { ...updated, viewer_has_voted: true } });
+}
+
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const auth = await requireAuth(request);
+  if ("error" in auth) {
+    return Response.json({ error: auth.error }, { status: auth.status ?? 400 });
+  }
+
+  const { id } = await params;
+  const admin = auth.admin;
+
+  const { error } = await admin
+    .from("module_request_votes")
+    .delete()
+    .eq("request_id", id)
+    .eq("user_id", auth.userId);
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+
+  const updated = await loadRequest(admin, id);
+  if (!updated) {
+    return Response.json({ error: "Not found." }, { status: 404 });
+  }
+
+  return Response.json({ item: { ...updated, viewer_has_voted: false } });
+}

--- a/src/app/api/modules/module-requests/_auth.ts
+++ b/src/app/api/modules/module-requests/_auth.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from "next/server";
+import { supabaseAdminClient } from "@/lib/supabase/admin";
+import { supabaseServerClient } from "@/lib/supabase/server";
+
+export type AuthResult =
+  | { error: string; status?: number }
+  | { userId: string; roles: string[]; admin: ReturnType<typeof supabaseAdminClient> };
+
+async function requireAuthInternal(request: NextRequest): Promise<AuthResult> {
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return { error: "Missing auth token.", status: 401 };
+  }
+
+  const token = authHeader.replace("Bearer ", "");
+  const supabase = supabaseServerClient();
+  const { data, error } = await supabase.auth.getUser(token);
+  if (error || !data.user) {
+    return { error: "Invalid auth token.", status: 401 };
+  }
+
+  const admin = supabaseAdminClient();
+  const { data: roleRows, error: rolesError } = await admin
+    .from("user_roles")
+    .select("role")
+    .eq("user_id", data.user.id);
+
+  if (rolesError) {
+    return { error: `Failed to load user roles: ${rolesError.message}`, status: 500 };
+  }
+
+  const roles = roleRows?.map((row) => row.role) ?? [];
+  return { userId: data.user.id, roles, admin };
+}
+
+export async function requireAuth(request: NextRequest): Promise<AuthResult> {
+  return requireAuthInternal(request);
+}
+
+export async function requireHost(request: NextRequest): Promise<AuthResult> {
+  const result = await requireAuthInternal(request);
+  if ("error" in result) return result;
+  if (!result.roles.includes("host")) {
+    return { error: "Host access required.", status: 403 };
+  }
+  return result;
+}

--- a/src/app/api/modules/module-requests/lib.ts
+++ b/src/app/api/modules/module-requests/lib.ts
@@ -1,0 +1,66 @@
+import type { Json } from "@/lib/types/db";
+
+export type ModuleRequestStatus =
+  | "draft"
+  | "open"
+  | "ready"
+  | "submitted_to_github"
+  | "archived";
+
+export type ModuleRequestSpec = {
+  module_id?: string;
+  owner?: string;
+  problem?: string;
+  scope?: string;
+  ux?: string;
+  storage?: string;
+  data_model?: string;
+  api?: string;
+  acceptance?: string;
+  testing?: string;
+  portal_rpc?: string;
+  allowed_origins?: string;
+  [key: string]: Json | undefined;
+};
+
+export function toGitHubIssueMarkdown(params: {
+  title: string;
+  moduleId: string;
+  ownerContact?: string | null;
+  spec: ModuleRequestSpec;
+}): string {
+  const { title, moduleId, ownerContact, spec } = params;
+
+  const section = (heading: string, value?: unknown) => {
+    const text = typeof value === "string" ? value.trim() : "";
+    return `### ${heading}\n\n${text || "_No response_"}\n`;
+  };
+
+  return [
+    `### Module ID\n\n${moduleId}\n`,
+    `### Title\n\n${title}\n`,
+    `### Owner / contact\n\n${ownerContact || spec.owner || "_No response_"}\n`,
+    section("Problem / user value", spec.problem),
+    section("Scope (what’s in / out)", spec.scope),
+    section("UX / surfaces", spec.ux),
+    section("Storage preference", spec.storage),
+    section("Data model (fields)", spec.data_model),
+    section("API requirements", spec.api),
+    section("Acceptance criteria", spec.acceptance),
+    section("Testing / seed data", spec.testing),
+    section("Portal RPC (optional)", spec.portal_rpc),
+    section("Allowed iframe origins (optional)", spec.allowed_origins),
+  ].join("\n");
+}
+
+export function normalizeStatus(input: unknown): ModuleRequestStatus | null {
+  const value = typeof input === "string" ? input.trim() : "";
+  const allowed: ModuleRequestStatus[] = [
+    "draft",
+    "open",
+    "ready",
+    "submitted_to_github",
+    "archived",
+  ];
+  return (allowed as string[]).includes(value) ? (value as ModuleRequestStatus) : null;
+}

--- a/src/app/api/modules/module-requests/route.ts
+++ b/src/app/api/modules/module-requests/route.ts
@@ -1,0 +1,131 @@
+import { NextRequest } from "next/server";
+import type { TablesInsert } from "@/lib/types/db";
+import { requireAuth } from "./_auth";
+import { normalizeStatus, type ModuleRequestSpec } from "./lib";
+
+const parseSort = (value: string | null) => {
+  const sort = (value ?? "").trim();
+  if (sort === "trending" || sort === "ready" || sort === "new") return sort;
+  return "new";
+};
+
+export async function GET(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if ("error" in auth) {
+    return Response.json({ error: auth.error }, { status: auth.status ?? 400 });
+  }
+
+  const url = new URL(request.url);
+  const status = normalizeStatus(url.searchParams.get("status"));
+  const sort = parseSort(url.searchParams.get("sort"));
+  const page = Math.max(1, Number(url.searchParams.get("page") ?? "1") || 1);
+  const limit = Math.min(50, Math.max(1, Number(url.searchParams.get("limit") ?? "20") || 20));
+  const from = (page - 1) * limit;
+  const to = from + limit - 1;
+
+  const admin = auth.admin;
+
+  let query = admin
+    .from("module_requests")
+    .select(
+      "id, created_by, module_id, title, owner_contact, status, spec, votes_count, promotion_threshold, github_issue_url, submitted_to_github_at, created_at, updated_at",
+      { count: "exact" },
+    )
+    .is("deleted_at", null);
+
+  if (status) {
+    query = query.eq("status", status);
+  } else {
+    // Default to open-ish states
+    query = query.in("status", ["open", "ready"]);
+  }
+
+  if (sort === "trending") {
+    query = query.order("votes_count", { ascending: false }).order("updated_at", { ascending: false });
+  } else if (sort === "ready") {
+    query = query.order("updated_at", { ascending: false });
+  } else {
+    query = query.order("created_at", { ascending: false });
+  }
+
+  const { data, error, count } = await query.range(from, to);
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+
+  // Determine viewer votes for returned rows.
+  const ids = (data ?? []).map((row) => row.id);
+  let votedIds = new Set<string>();
+  if (ids.length) {
+    const { data: voteRows } = await admin
+      .from("module_request_votes")
+      .select("request_id")
+      .eq("user_id", auth.userId)
+      .in("request_id", ids);
+
+    votedIds = new Set((voteRows ?? []).map((row) => row.request_id));
+  }
+
+  return Response.json({
+    items: (data ?? []).map((row) => ({
+      ...row,
+      viewer_has_voted: votedIds.has(row.id),
+    })),
+    page,
+    limit,
+    total: count ?? null,
+  });
+}
+
+type CreateRequestBody = {
+  title?: string;
+  module_id?: string;
+  owner_contact?: string;
+  spec?: ModuleRequestSpec;
+};
+
+export async function POST(request: NextRequest) {
+  const auth = await requireAuth(request);
+  if ("error" in auth) {
+    return Response.json({ error: auth.error }, { status: auth.status ?? 400 });
+  }
+
+  let body: CreateRequestBody;
+  try {
+    body = (await request.json()) as CreateRequestBody;
+  } catch {
+    return Response.json({ error: "Invalid JSON." }, { status: 400 });
+  }
+
+  const title = String(body.title ?? "").trim();
+  const moduleId = String(body.module_id ?? "").trim();
+  if (!title) {
+    return Response.json({ error: "Title is required." }, { status: 400 });
+  }
+  if (!moduleId) {
+    return Response.json({ error: "module_id is required." }, { status: 400 });
+  }
+
+  const insert: TablesInsert<"module_requests"> = {
+    created_by: auth.userId,
+    title,
+    module_id: moduleId,
+    owner_contact: typeof body.owner_contact === "string" ? body.owner_contact.trim() : null,
+    status: "draft",
+    spec: (body.spec ?? {}) as ModuleRequestSpec,
+  };
+
+  const { data, error } = await auth.admin
+    .from("module_requests")
+    .insert(insert)
+    .select(
+      "id, created_by, module_id, title, owner_contact, status, spec, votes_count, promotion_threshold, github_issue_url, submitted_to_github_at, created_at, updated_at",
+    )
+    .single();
+
+  if (error) {
+    return Response.json({ error: error.message }, { status: 500 });
+  }
+
+  return Response.json({ item: data });
+}

--- a/src/app/me/page.tsx
+++ b/src/app/me/page.tsx
@@ -369,7 +369,7 @@ export default function MePage() {
     }
   };
 
-  const handleProfileSave = async (options?: { silent?: boolean }) => {
+  const handleProfileSave = useCallback(async (options?: { silent?: boolean }) => {
     if (!user) {
       if (!options?.silent) {
         setMessage("Please sign in first.");
@@ -460,7 +460,7 @@ export default function MePage() {
       window.postMessage({ type: "profile-updated" }, window.location.origin);
     }
     return !error;
-  };
+  }, [profile, profileExists, supabase, user]);
 
   useEffect(() => {
     if (!session) return;

--- a/src/app/modules/module-requests/[id]/page.tsx
+++ b/src/app/modules/module-requests/[id]/page.tsx
@@ -1,0 +1,8 @@
+import { ModuleRequestDetail } from "@/modules/module-requests/ModuleRequestDetail";
+
+export default async function ModuleRequestDetailPage(props: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await props.params;
+  return <ModuleRequestDetail id={id} />;
+}

--- a/src/app/modules/module-requests/new/page.tsx
+++ b/src/app/modules/module-requests/new/page.tsx
@@ -1,0 +1,16 @@
+import { ModuleRequestCreateForm } from "@/modules/module-requests/ModuleRequestCreateForm";
+
+export default function ModuleRequestsNewPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-semibold">New module request</h1>
+        <p className="text-sm text-muted-foreground">
+          Start a draft. Publish when it’s ready for others to vote.
+        </p>
+      </div>
+
+      <ModuleRequestCreateForm />
+    </div>
+  );
+}

--- a/src/app/modules/module-requests/page.tsx
+++ b/src/app/modules/module-requests/page.tsx
@@ -1,0 +1,16 @@
+import { ModuleRequests } from "@/modules/module-requests/ModuleRequests";
+
+export default function ModuleRequestsPage() {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-semibold">Module Requests</h1>
+        <p className="text-sm text-muted-foreground">
+          Propose new portal modules and vote on what the cohort should build next.
+        </p>
+      </div>
+
+      <ModuleRequests />
+    </div>
+  );
+}

--- a/src/lib/types/db.ts
+++ b/src/lib/types/db.ts
@@ -334,6 +334,75 @@ export type Database = {
         }
         Relationships: []
       }
+      module_requests: {
+        Row: {
+          id: string
+          created_by: string
+          module_id: string
+          title: string
+          owner_contact: string | null
+          status: string
+          spec: Json
+          votes_count: number
+          promotion_threshold: number
+          github_issue_url: string | null
+          submitted_to_github_at: string | null
+          created_at: string
+          updated_at: string
+          deleted_at: string | null
+        }
+        Insert: {
+          id?: string
+          created_by: string
+          module_id: string
+          title: string
+          owner_contact?: string | null
+          status?: string
+          spec?: Json
+          votes_count?: number
+          promotion_threshold?: number
+          github_issue_url?: string | null
+          submitted_to_github_at?: string | null
+          created_at?: string
+          updated_at?: string
+          deleted_at?: string | null
+        }
+        Update: {
+          id?: string
+          created_by?: string
+          module_id?: string
+          title?: string
+          owner_contact?: string | null
+          status?: string
+          spec?: Json
+          votes_count?: number
+          promotion_threshold?: number
+          github_issue_url?: string | null
+          submitted_to_github_at?: string | null
+          created_at?: string
+          updated_at?: string
+          deleted_at?: string | null
+        }
+        Relationships: []
+      }
+      module_request_votes: {
+        Row: {
+          request_id: string
+          user_id: string
+          created_at: string
+        }
+        Insert: {
+          request_id: string
+          user_id: string
+          created_at?: string
+        }
+        Update: {
+          request_id?: string
+          user_id?: string
+          created_at?: string
+        }
+        Relationships: []
+      }
       timeline_entries: {
         Row: {
           body: string | null

--- a/src/modules/module-requests/ModuleRequestCreateForm.tsx
+++ b/src/modules/module-requests/ModuleRequestCreateForm.tsx
@@ -1,0 +1,235 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabaseBrowserClient } from "@/lib/supabase/client";
+import type { ModuleRequest } from "./types";
+
+type Spec = {
+  problem: string;
+  scope: string;
+  ux: string;
+  storage: string;
+  data_model: string;
+  api: string;
+  acceptance: string;
+  testing: string;
+  portal_rpc: string;
+  allowed_origins: string;
+};
+
+const emptySpec: Spec = {
+  problem: "",
+  scope: "",
+  ux: "",
+  storage: "module_data (per-user JSON)",
+  data_model: "",
+  api: "",
+  acceptance: "",
+  testing: "",
+  portal_rpc: "",
+  allowed_origins: "",
+};
+
+export function ModuleRequestCreateForm() {
+  const supabase = useMemo(() => supabaseBrowserClient(), []);
+  const router = useRouter();
+
+  const [title, setTitle] = useState("");
+  const [moduleId, setModuleId] = useState("");
+  const [ownerContact, setOwnerContact] = useState("");
+  const [spec, setSpec] = useState<Spec>(emptySpec);
+
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const saveDraft = async () => {
+    setSaving(true);
+    setError(null);
+
+    try {
+      const { data } = await supabase.auth.getSession();
+      const accessToken = data.session?.access_token;
+      if (!accessToken) {
+        throw new Error("You must be signed in.");
+      }
+
+      const res = await fetch("/api/modules/module-requests", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title,
+          module_id: moduleId,
+          owner_contact: ownerContact || null,
+          spec,
+        }),
+      });
+
+      const json = (await res.json()) as { request?: ModuleRequest; error?: string };
+      if (!res.ok) {
+        throw new Error(json.error || "Failed to create request.");
+      }
+
+      const requestId = json.request?.id;
+      if (!requestId) {
+        throw new Error("Missing request id.");
+      }
+
+      router.push(`/modules/module-requests/${requestId}`);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create request.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <Link
+          href="/modules/module-requests"
+          className="text-sm text-muted-foreground hover:underline"
+        >
+          ← Back
+        </Link>
+        <button
+          type="button"
+          onClick={() => saveDraft()}
+          disabled={saving}
+          className="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-60"
+        >
+          {saving ? "Saving..." : "Save draft"}
+        </button>
+      </div>
+
+      {error ? <div className="text-sm text-red-500">{error}</div> : null}
+
+      <div className="grid gap-3 rounded-xl border border-border bg-card p-4">
+        <label className="grid gap-1 text-sm">
+          <span className="text-xs text-muted-foreground">Title</span>
+          <input
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            maxLength={120}
+            className="h-10 rounded-lg border border-border bg-background px-3"
+            placeholder="Short label for lists"
+          />
+        </label>
+
+        <label className="grid gap-1 text-sm">
+          <span className="text-xs text-muted-foreground">Suggested module_id</span>
+          <input
+            value={moduleId}
+            onChange={(e) => setModuleId(e.target.value)}
+            maxLength={64}
+            className="h-10 rounded-lg border border-border bg-background px-3"
+            placeholder="kebab-case (e.g. module-requests)"
+          />
+        </label>
+
+        <label className="grid gap-1 text-sm">
+          <span className="text-xs text-muted-foreground">Owner / contact</span>
+          <input
+            value={ownerContact}
+            onChange={(e) => setOwnerContact(e.target.value)}
+            maxLength={256}
+            className="h-10 rounded-lg border border-border bg-background px-3"
+            placeholder="discord:@you"
+          />
+        </label>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <TextArea
+            label="Problem / user value"
+            required
+            value={spec.problem}
+            onChange={(v) => setSpec((s) => ({ ...s, problem: v }))}
+          />
+          <TextArea
+            label="Scope (what’s in / out)"
+            required
+            value={spec.scope}
+            onChange={(v) => setSpec((s) => ({ ...s, scope: v }))}
+          />
+          <TextArea
+            label="UX / surfaces"
+            required
+            value={spec.ux}
+            onChange={(v) => setSpec((s) => ({ ...s, ux: v }))}
+          />
+          <TextArea
+            label="Storage preference"
+            value={spec.storage}
+            onChange={(v) => setSpec((s) => ({ ...s, storage: v }))}
+          />
+          <TextArea
+            label="Data model"
+            value={spec.data_model}
+            onChange={(v) => setSpec((s) => ({ ...s, data_model: v }))}
+          />
+          <TextArea
+            label="API requirements"
+            value={spec.api}
+            onChange={(v) => setSpec((s) => ({ ...s, api: v }))}
+          />
+          <TextArea
+            label="Acceptance criteria"
+            value={spec.acceptance}
+            onChange={(v) => setSpec((s) => ({ ...s, acceptance: v }))}
+          />
+          <TextArea
+            label="Testing / seed data"
+            value={spec.testing}
+            onChange={(v) => setSpec((s) => ({ ...s, testing: v }))}
+          />
+          <TextArea
+            label="Portal RPC (optional)"
+            value={spec.portal_rpc}
+            onChange={(v) => setSpec((s) => ({ ...s, portal_rpc: v }))}
+          />
+          <TextArea
+            label="Allowed iframe origins (optional)"
+            value={spec.allowed_origins}
+            onChange={(v) => setSpec((s) => ({ ...s, allowed_origins: v }))}
+          />
+        </div>
+
+        <div className="text-xs text-muted-foreground">
+          Drafts are private to you until you publish.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function TextArea({
+  label,
+  required,
+  value,
+  onChange,
+}: {
+  label: string;
+  required?: boolean;
+  value: string;
+  onChange: (v: string) => void;
+}) {
+  return (
+    <label className="grid gap-1 text-sm">
+      <span className="text-xs text-muted-foreground">
+        {label}
+        {required ? " *" : ""}
+      </span>
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        className="min-h-24 rounded-lg border border-border bg-background p-3"
+        placeholder={required ? "Required" : "Optional"}
+      />
+    </label>
+  );
+}

--- a/src/modules/module-requests/ModuleRequestDetail.tsx
+++ b/src/modules/module-requests/ModuleRequestDetail.tsx
@@ -1,0 +1,332 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useRouter } from "next/navigation";
+import { supabaseBrowserClient } from "@/lib/supabase/client";
+import { HostOnly } from "@/components/HostOnly";
+import type { ModuleRequest } from "./types";
+
+export function ModuleRequestDetail({ id }: { id: string }) {
+  const supabase = useMemo(() => supabaseBrowserClient(), []);
+  const router = useRouter();
+
+  const [request, setRequest] = useState<ModuleRequest | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [markdown, setMarkdown] = useState<string | null>(null);
+  const [githubUrl, setGithubUrl] = useState("");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { data } = await supabase.auth.getSession();
+      const accessToken = data.session?.access_token;
+      if (!accessToken) {
+        setRequest(null);
+        setError("You must be signed in to view this request.");
+        return;
+      }
+
+      const res = await fetch(`/api/modules/module-requests/${id}`, {
+        cache: "no-store",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      const json = (await res.json()) as { request?: ModuleRequest; error?: string };
+      if (!res.ok) {
+        throw new Error(json.error || "Failed to load request.");
+      }
+      setRequest(json.request ?? null);
+    } catch (err) {
+      setRequest(null);
+      setError(err instanceof Error ? err.message : "Failed to load request.");
+    } finally {
+      setLoading(false);
+    }
+  }, [id, supabase]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const call = async (path: string, init?: RequestInit) => {
+    const { data } = await supabase.auth.getSession();
+    const accessToken = data.session?.access_token;
+    if (!accessToken) {
+      throw new Error("You must be signed in.");
+    }
+
+    const res = await fetch(path, {
+      ...init,
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        ...(init?.headers ?? {}),
+      },
+    });
+
+    const json = (await res.json().catch(() => ({}))) as Record<string, unknown>;
+    if (!res.ok) {
+      throw new Error(typeof json.error === "string" ? json.error : "Request failed.");
+    }
+    return json;
+  };
+
+  const publish = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await call(`/api/modules/module-requests/${id}/publish`, { method: "POST" });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to publish.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const vote = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await call(`/api/modules/module-requests/${id}/vote`, { method: "POST" });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to vote.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const unvote = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      await call(`/api/modules/module-requests/${id}/vote`, { method: "DELETE" });
+      await load();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to unvote.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const promote = async (withLink: boolean) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const json = (await call(`/api/modules/module-requests/${id}/promote`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ github_issue_url: withLink ? githubUrl : undefined }),
+      })) as { markdown?: string; request?: ModuleRequest };
+
+      setMarkdown(typeof json.markdown === "string" ? json.markdown : null);
+      if (json.request) {
+        setRequest(json.request);
+      } else {
+        await load();
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to promote.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (loading && !request) {
+    return <div className="text-sm text-muted-foreground">Loading...</div>;
+  }
+
+  if (!request) {
+    return (
+      <div className="space-y-2">
+        <Link
+          href="/modules/module-requests"
+          className="text-sm text-muted-foreground hover:underline"
+        >
+          ← Back
+        </Link>
+        <div className="rounded-xl border border-border bg-card p-4 text-sm">
+          {error ?? "Not found."}
+        </div>
+      </div>
+    );
+  }
+
+  const spec = request.spec ?? {};
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3">
+        <Link
+          href="/modules/module-requests"
+          className="text-sm text-muted-foreground hover:underline"
+        >
+          ← Back
+        </Link>
+        <button
+          type="button"
+          onClick={() => {
+            router.refresh();
+            load();
+          }}
+          className="inline-flex h-9 items-center justify-center rounded-lg border border-border px-3 text-sm hover:bg-muted"
+        >
+          Refresh
+        </button>
+      </div>
+
+      <div className="rounded-xl border border-border bg-card p-4">
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div>
+            <h1 className="text-2xl font-semibold">{request.title}</h1>
+            <div className="mt-1 text-sm text-muted-foreground">
+              <span className="font-mono">{request.module_id}</span> · {request.status}
+            </div>
+          </div>
+          <div className="text-sm text-muted-foreground">
+            Votes: {request.votes_count} / {request.promotion_threshold}
+          </div>
+        </div>
+
+        <div className="mt-4 flex flex-wrap items-center gap-2">
+          {request.status === "draft" ? (
+            <button
+              type="button"
+              disabled={saving}
+              onClick={() => publish()}
+              className="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-60"
+            >
+              Publish
+            </button>
+          ) : null}
+
+          <button
+            type="button"
+            disabled={saving}
+            onClick={() => vote()}
+            className="inline-flex h-10 items-center justify-center rounded-lg border border-border px-4 text-sm hover:bg-muted disabled:opacity-60"
+          >
+            Vote
+          </button>
+          <button
+            type="button"
+            disabled={saving}
+            onClick={() => unvote()}
+            className="inline-flex h-10 items-center justify-center rounded-lg border border-border px-4 text-sm hover:bg-muted disabled:opacity-60"
+          >
+            Unvote
+          </button>
+
+          {request.github_issue_url ? (
+            <a
+              className="inline-flex h-10 items-center justify-center rounded-lg border border-border px-4 text-sm hover:bg-muted"
+              href={request.github_issue_url}
+              target="_blank"
+              rel="noreferrer"
+            >
+              View GitHub issue
+            </a>
+          ) : null}
+        </div>
+
+        {error ? <div className="mt-3 text-sm text-red-500">{error}</div> : null}
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <SpecCard title="Problem / user value" value={readSpec(spec, "problem")} />
+        <SpecCard title="Scope (what’s in / out)" value={readSpec(spec, "scope")} />
+        <SpecCard title="UX / surfaces" value={readSpec(spec, "ux")} />
+        <SpecCard title="Storage preference" value={readSpec(spec, "storage")} />
+        <SpecCard title="Data model" value={readSpec(spec, "data_model")} />
+        <SpecCard title="API requirements" value={readSpec(spec, "api")} />
+        <SpecCard title="Acceptance criteria" value={readSpec(spec, "acceptance")} />
+        <SpecCard title="Testing / seed data" value={readSpec(spec, "testing")} />
+        <SpecCard title="Portal RPC (optional)" value={readSpec(spec, "portal_rpc")} />
+        <SpecCard
+          title="Allowed iframe origins (optional)"
+          value={readSpec(spec, "allowed_origins")}
+        />
+      </div>
+
+      <HostOnly
+        fallback={
+          request.status === "ready" ? (
+            <div className="rounded-xl border border-border bg-card p-4 text-sm text-muted-foreground">
+              Ready for GitHub. Host access required to promote.
+            </div>
+          ) : null
+        }
+      >
+        {request.status === "ready" || request.status === "open" ? (
+          <div className="rounded-xl border border-border bg-card p-4">
+            <div className="text-sm font-semibold">Promote to GitHub</div>
+            <div className="mt-1 text-sm text-muted-foreground">
+              Generate a GitHub-ready issue body. Optionally paste the created GitHub issue URL to mark as submitted.
+            </div>
+
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() => promote(false)}
+                className="inline-flex h-10 items-center justify-center rounded-lg border border-border px-4 text-sm hover:bg-muted disabled:opacity-60"
+              >
+                Generate markdown
+              </button>
+              <input
+                value={githubUrl}
+                onChange={(e) => setGithubUrl(e.target.value)}
+                className="h-10 min-w-64 flex-1 rounded-lg border border-border bg-background px-3 text-sm"
+                placeholder="https://github.com/org/repo/issues/123"
+              />
+              <button
+                type="button"
+                disabled={saving}
+                onClick={() => promote(true)}
+                className="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-60"
+              >
+                Store link
+              </button>
+            </div>
+
+            {markdown ? (
+              <div className="mt-3">
+                <div className="text-xs text-muted-foreground">Markdown</div>
+                <textarea
+                  value={markdown}
+                  readOnly
+                  className="mt-1 min-h-56 w-full rounded-lg border border-border bg-background p-3 font-mono text-xs"
+                />
+              </div>
+            ) : null}
+          </div>
+        ) : null}
+      </HostOnly>
+    </div>
+  );
+}
+
+function readSpec(spec: Record<string, unknown>, key: string): string {
+  const raw = spec[key];
+  if (typeof raw !== "string") return "";
+  return raw;
+}
+
+function SpecCard({ title, value }: { title: string; value: string }) {
+  return (
+    <div className="rounded-xl border border-border bg-card p-4">
+      <div className="text-sm font-semibold">{title}</div>
+      {value ? (
+        <pre className="mt-2 whitespace-pre-wrap text-sm text-muted-foreground">
+          {value}
+        </pre>
+      ) : (
+        <div className="mt-2 text-sm text-muted-foreground">—</div>
+      )}
+    </div>
+  );
+}

--- a/src/modules/module-requests/ModuleRequests.tsx
+++ b/src/modules/module-requests/ModuleRequests.tsx
@@ -1,0 +1,516 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { supabaseBrowserClient } from "@/lib/supabase/client";
+
+type ModuleRequestStatus =
+  | "draft"
+  | "open"
+  | "ready"
+  | "submitted_to_github"
+  | "archived";
+
+type ModuleRequest = {
+  id: string;
+  created_by: string;
+  module_id: string;
+  title: string;
+  owner_contact: string | null;
+  status: ModuleRequestStatus;
+  spec: Record<string, unknown>;
+  votes_count: number;
+  promotion_threshold: number;
+  github_issue_url: string | null;
+  submitted_to_github_at: string | null;
+  created_at: string;
+  updated_at: string;
+  viewer_has_voted?: boolean;
+};
+
+type ListSort = "new" | "trending" | "ready";
+
+type Tab = "new" | "trending" | "ready" | "archived";
+
+const TAB_TO_QUERY: Record<Tab, { sort: ListSort; status?: ModuleRequestStatus }>= {
+  new: { sort: "new", status: "open" },
+  trending: { sort: "trending", status: "open" },
+  ready: { sort: "ready", status: "ready" },
+  archived: { sort: "new", status: "archived" },
+};
+
+function formatDate(input: string) {
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) return input;
+  return date.toLocaleDateString();
+}
+
+export function ModuleRequests() {
+  const supabase = useMemo(() => supabaseBrowserClient(), []);
+  const [tab, setTab] = useState<Tab>("new");
+  const [items, setItems] = useState<ModuleRequest[]>([]);
+  const [selected, setSelected] = useState<ModuleRequest | null>(null);
+
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const [createTitle, setCreateTitle] = useState("");
+  const [createModuleId, setCreateModuleId] = useState("");
+  const [createProblem, setCreateProblem] = useState("");
+  const [createScope, setCreateScope] = useState("");
+  const [createUx, setCreateUx] = useState("");
+
+  const loadList = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { data } = await supabase.auth.getSession();
+      const token = data.session?.access_token;
+      if (!token) {
+        setItems([]);
+        setSelected(null);
+        setError("You must be signed in to browse module requests.");
+        return;
+      }
+
+      const q = TAB_TO_QUERY[tab];
+      const url = new URL("/api/modules/module-requests", window.location.origin);
+      url.searchParams.set("sort", q.sort);
+      if (q.status) url.searchParams.set("status", q.status);
+
+      const res = await fetch(url.toString(), {
+        cache: "no-store",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const json = (await res.json()) as { items?: ModuleRequest[]; error?: string };
+      if (!res.ok) {
+        throw new Error(json.error || "Failed to load requests.");
+      }
+      setItems(json.items ?? []);
+      if (selected) {
+        const next = (json.items ?? []).find((r) => r.id === selected.id) ?? null;
+        setSelected(next);
+      }
+    } catch (err) {
+      setItems([]);
+      setSelected(null);
+      setError(err instanceof Error ? err.message : "Failed to load requests.");
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase, tab, selected]);
+
+  useEffect(() => {
+    loadList();
+  }, [loadList]);
+
+  const openDetail = async (id: string) => {
+    setError(null);
+    try {
+      const { data } = await supabase.auth.getSession();
+      const token = data.session?.access_token;
+      if (!token) {
+        setError("You must be signed in.");
+        return;
+      }
+      const res = await fetch(`/api/modules/module-requests/${id}`, {
+        cache: "no-store",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const json = (await res.json()) as { item?: ModuleRequest; error?: string };
+      if (!res.ok) {
+        throw new Error(json.error || "Failed to load request.");
+      }
+      setSelected(json.item ?? null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to load request.");
+    }
+  };
+
+  const createDraft = async () => {
+    setSaving(true);
+    setError(null);
+    try {
+      const { data } = await supabase.auth.getSession();
+      const token = data.session?.access_token;
+      if (!token) {
+        setError("You must be signed in.");
+        return;
+      }
+
+      const res = await fetch("/api/modules/module-requests", {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${token}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          title: createTitle,
+          module_id: createModuleId,
+          spec: {
+            problem: createProblem,
+            scope: createScope,
+            ux: createUx,
+          },
+        }),
+      });
+
+      const json = (await res.json()) as { item?: ModuleRequest; error?: string };
+      if (!res.ok) {
+        throw new Error(json.error || "Failed to create request.");
+      }
+
+      setCreateTitle("");
+      setCreateModuleId("");
+      setCreateProblem("");
+      setCreateScope("");
+      setCreateUx("");
+
+      await loadList();
+      if (json.item?.id) {
+        await openDetail(json.item.id);
+      }
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to create request.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const publish = async (id: string) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const { data } = await supabase.auth.getSession();
+      const token = data.session?.access_token;
+      if (!token) {
+        setError("You must be signed in.");
+        return;
+      }
+
+      const res = await fetch(`/api/modules/module-requests/${id}/publish`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const json = (await res.json()) as { item?: ModuleRequest; error?: string };
+      if (!res.ok) {
+        throw new Error(json.error || "Failed to publish request.");
+      }
+
+      setSelected(json.item ?? null);
+      await loadList();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to publish request.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const vote = async (id: string, next: boolean) => {
+    setSaving(true);
+    setError(null);
+    try {
+      const { data } = await supabase.auth.getSession();
+      const token = data.session?.access_token;
+      if (!token) {
+        setError("You must be signed in.");
+        return;
+      }
+
+      const res = await fetch(`/api/modules/module-requests/${id}/vote`, {
+        method: next ? "POST" : "DELETE",
+        headers: { Authorization: `Bearer ${token}` },
+      });
+      const json = (await res.json()) as { item?: ModuleRequest; error?: string };
+      if (!res.ok) {
+        throw new Error(json.error || "Failed to update vote.");
+      }
+
+      setSelected(json.item ?? null);
+      await loadList();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to update vote.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="grid gap-6 lg:grid-cols-[1fr_420px]">
+      <div className="space-y-4">
+        <div className="rounded-xl border border-border bg-card p-4">
+          <div className="flex flex-wrap items-center gap-2">
+            {(["new", "trending", "ready", "archived"] as Tab[]).map((t) => (
+              <button
+                key={t}
+                type="button"
+                onClick={() => {
+                  setSelected(null);
+                  setTab(t);
+                }}
+                className={`inline-flex h-9 items-center justify-center rounded-lg px-3 text-sm ${
+                  tab === t
+                    ? "bg-primary text-primary-foreground"
+                    : "border border-border hover:bg-muted"
+                }`}
+              >
+                {t[0].toUpperCase() + t.slice(1)}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => loadList()}
+              className="ml-auto inline-flex h-9 items-center justify-center rounded-lg border border-border px-3 text-sm hover:bg-muted"
+            >
+              Refresh
+            </button>
+          </div>
+
+          {loading && !items.length ? (
+            <div className="mt-3 text-sm text-muted-foreground">Loading…</div>
+          ) : null}
+
+          {!loading && !items.length ? (
+            <div className="mt-3 text-sm text-muted-foreground">No requests found.</div>
+          ) : null}
+
+          {items.length ? (
+            <div className="mt-4 grid gap-3">
+              {items.map((r) => {
+                const isReady = r.status === "ready";
+                const voted = Boolean(r.viewer_has_voted);
+                return (
+                  <div
+                    key={r.id}
+                    className={`rounded-xl border border-border p-4 ${
+                      selected?.id === r.id ? "bg-muted/40" : "bg-card"
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <button
+                          type="button"
+                          onClick={() => openDetail(r.id)}
+                          className="text-left text-sm font-semibold hover:underline"
+                        >
+                          {r.title}
+                        </button>
+                        <div className="mt-1 text-xs text-muted-foreground">
+                          <span className="font-mono">{r.module_id}</span>
+                          <span className="mx-2">·</span>
+                          <span>{formatDate(r.created_at)}</span>
+                          <span className="mx-2">·</span>
+                          <span className="capitalize">{r.status.replaceAll("_", " ")}</span>
+                        </div>
+                      </div>
+                      <div className="text-right">
+                        <div className="text-sm font-semibold">{r.votes_count}</div>
+                        <div className="text-[11px] text-muted-foreground">votes</div>
+                      </div>
+                    </div>
+
+                    <div className="mt-3 flex flex-wrap items-center gap-2">
+                      <button
+                        type="button"
+                        disabled={saving || r.status === "archived" || r.status === "submitted_to_github"}
+                        onClick={() => vote(r.id, !voted)}
+                        className={`inline-flex h-9 items-center justify-center rounded-lg px-3 text-sm ${
+                          voted ? "bg-primary text-primary-foreground" : "border border-border hover:bg-muted"
+                        } disabled:opacity-60`}
+                      >
+                        {voted ? "Voted" : "Vote"}
+                      </button>
+                      <div className="text-xs text-muted-foreground">
+                        {r.votes_count} / {r.promotion_threshold} {isReady ? "(Ready)" : "to Ready"}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="rounded-xl border border-border bg-card p-4">
+          <div className="text-sm font-semibold">Create a request (draft)</div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Minimal v0 form. You can expand details after creation.
+          </p>
+
+          <div className="mt-4 grid gap-3">
+            <label className="grid gap-1 text-sm">
+              <span className="text-xs text-muted-foreground">Title *</span>
+              <input
+                value={createTitle}
+                onChange={(e) => setCreateTitle(e.target.value)}
+                className="h-10 rounded-lg border border-border bg-background px-3"
+                placeholder="e.g. Module Requests"
+              />
+            </label>
+
+            <label className="grid gap-1 text-sm">
+              <span className="text-xs text-muted-foreground">module_id (kebab-case) *</span>
+              <input
+                value={createModuleId}
+                onChange={(e) => setCreateModuleId(e.target.value)}
+                className="h-10 rounded-lg border border-border bg-background px-3 font-mono"
+                placeholder="e.g. module-requests"
+              />
+            </label>
+
+            <label className="grid gap-1 text-sm">
+              <span className="text-xs text-muted-foreground">Problem *</span>
+              <textarea
+                value={createProblem}
+                onChange={(e) => setCreateProblem(e.target.value)}
+                className="min-h-20 rounded-lg border border-border bg-background p-3"
+              />
+            </label>
+
+            <label className="grid gap-1 text-sm">
+              <span className="text-xs text-muted-foreground">Scope *</span>
+              <textarea
+                value={createScope}
+                onChange={(e) => setCreateScope(e.target.value)}
+                className="min-h-20 rounded-lg border border-border bg-background p-3"
+              />
+            </label>
+
+            <label className="grid gap-1 text-sm">
+              <span className="text-xs text-muted-foreground">UX *</span>
+              <textarea
+                value={createUx}
+                onChange={(e) => setCreateUx(e.target.value)}
+                className="min-h-20 rounded-lg border border-border bg-background p-3"
+              />
+            </label>
+
+            <button
+              type="button"
+              disabled={saving}
+              onClick={() => createDraft()}
+              className="inline-flex h-10 items-center justify-center rounded-lg bg-primary px-4 text-sm font-medium text-primary-foreground disabled:opacity-60"
+            >
+              {saving ? "Saving…" : "Save draft"}
+            </button>
+          </div>
+        </div>
+
+        {error ? <div className="text-sm text-red-500">{error}</div> : null}
+      </div>
+
+      <div className="space-y-4">
+        <div className="rounded-xl border border-border bg-card p-4">
+          <div className="text-sm font-semibold">Request detail</div>
+          {!selected ? (
+            <div className="mt-3 text-sm text-muted-foreground">
+              Select a request to see the full spec.
+            </div>
+          ) : (
+            <div className="mt-3 space-y-3">
+              <div>
+                <div className="text-lg font-semibold">{selected.title}</div>
+                <div className="text-xs text-muted-foreground">
+                  <span className="font-mono">{selected.module_id}</span>
+                  <span className="mx-2">·</span>
+                  <span className="capitalize">{selected.status.replaceAll("_", " ")}</span>
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-border bg-muted/40 p-3 text-sm">
+                <div className="flex items-center justify-between">
+                  <div>
+                    Votes: <span className="font-semibold">{selected.votes_count}</span>
+                    <span className="text-muted-foreground">
+                      {" "}/ {selected.promotion_threshold}
+                    </span>
+                  </div>
+                  <button
+                    type="button"
+                    disabled={saving || selected.status === "archived" || selected.status === "submitted_to_github"}
+                    onClick={() => vote(selected.id, !selected.viewer_has_voted)}
+                    className={`inline-flex h-9 items-center justify-center rounded-lg px-3 text-sm ${
+                      selected.viewer_has_voted
+                        ? "bg-primary text-primary-foreground"
+                        : "border border-border hover:bg-muted"
+                    } disabled:opacity-60`}
+                  >
+                    {selected.viewer_has_voted ? "Voted" : "Vote"}
+                  </button>
+                </div>
+              </div>
+
+              {selected.status === "draft" ? (
+                <button
+                  type="button"
+                  disabled={saving}
+                  onClick={() => publish(selected.id)}
+                  className="inline-flex h-10 w-full items-center justify-center rounded-lg border border-border px-4 text-sm hover:bg-muted disabled:opacity-60"
+                >
+                  {saving ? "Publishing…" : "Publish (draft → open)"}
+                </button>
+              ) : null}
+
+              {selected.github_issue_url ? (
+                <a
+                  href={selected.github_issue_url}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="block text-sm text-primary hover:underline"
+                >
+                  View GitHub issue
+                </a>
+              ) : null}
+
+              <div className="space-y-3">
+                {([
+                  ["Problem", selected.spec?.problem],
+                  ["Scope", selected.spec?.scope],
+                  ["UX", selected.spec?.ux],
+                  ["Storage", selected.spec?.storage],
+                  ["Data model", selected.spec?.data_model],
+                  ["API", selected.spec?.api],
+                  ["Acceptance", selected.spec?.acceptance],
+                  ["Testing", selected.spec?.testing],
+                  ["Portal RPC", selected.spec?.portal_rpc],
+                  ["Allowed origins", selected.spec?.allowed_origins],
+                ] as Array<[string, unknown]>).map(([label, value]) => {
+                  const text = typeof value === "string" ? value : "";
+                  if (!text.trim()) return null;
+                  return (
+                    <div key={label}>
+                      <div className="text-xs font-semibold text-muted-foreground">{label}</div>
+                      <pre className="mt-1 whitespace-pre-wrap rounded-lg border border-border bg-background p-3 text-sm">
+                        {text}
+                      </pre>
+                    </div>
+                  );
+                })}
+              </div>
+
+              <div className="text-xs text-muted-foreground">
+                Created: {formatDate(selected.created_at)} · Updated: {formatDate(selected.updated_at)}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <div className="rounded-xl border border-border bg-card p-4">
+          <div className="text-sm font-semibold">Host promotion</div>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Promotion is host-only and is available via the API endpoint:
+          </p>
+          <pre className="mt-2 whitespace-pre-wrap rounded-lg border border-border bg-background p-3 text-xs">
+            POST /api/modules/module-requests/:id/promote
+          </pre>
+          <p className="mt-2 text-sm text-muted-foreground">
+            This returns a GitHub-ready markdown body. Optionally provide a
+            <span className="font-mono"> github_issue_url</span> to store the link and
+            transition to <span className="font-mono">submitted_to_github</span>.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/module-requests/ModuleRequestsList.tsx
+++ b/src/modules/module-requests/ModuleRequestsList.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import Link from "next/link";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { supabaseBrowserClient } from "@/lib/supabase/client";
+import type { ModuleRequest } from "./types";
+
+type Sort = "new" | "trending" | "ready";
+
+export function ModuleRequestsList() {
+  const supabase = useMemo(() => supabaseBrowserClient(), []);
+
+  const [requests, setRequests] = useState<ModuleRequest[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [sort, setSort] = useState<Sort>("new");
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const { data } = await supabase.auth.getSession();
+      const accessToken = data.session?.access_token;
+      if (!accessToken) {
+        setRequests([]);
+        setError("You must be signed in to view module requests.");
+        return;
+      }
+
+      const res = await fetch(`/api/modules/module-requests?sort=${sort}`, {
+        cache: "no-store",
+        headers: { Authorization: `Bearer ${accessToken}` },
+      });
+      const json = (await res.json()) as { requests?: ModuleRequest[]; error?: string };
+      if (!res.ok) {
+        throw new Error(json.error || "Failed to load requests.");
+      }
+      setRequests(json.requests ?? []);
+    } catch (err) {
+      setRequests([]);
+      setError(err instanceof Error ? err.message : "Failed to load requests.");
+    } finally {
+      setLoading(false);
+    }
+  }, [sort, supabase]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => setSort("new")}
+            className={`h-9 rounded-lg border border-border px-3 text-sm ${
+              sort === "new" ? "bg-muted" : "hover:bg-muted"
+            }`}
+          >
+            New
+          </button>
+          <button
+            type="button"
+            onClick={() => setSort("trending")}
+            className={`h-9 rounded-lg border border-border px-3 text-sm ${
+              sort === "trending" ? "bg-muted" : "hover:bg-muted"
+            }`}
+          >
+            Trending
+          </button>
+          <button
+            type="button"
+            onClick={() => setSort("ready")}
+            className={`h-9 rounded-lg border border-border px-3 text-sm ${
+              sort === "ready" ? "bg-muted" : "hover:bg-muted"
+            }`}
+          >
+            Ready
+          </button>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <Link
+            href="/modules/module-requests/new"
+            className="inline-flex h-9 items-center justify-center rounded-lg bg-primary px-3 text-sm font-medium text-primary-foreground"
+          >
+            New request
+          </Link>
+          <button
+            type="button"
+            onClick={() => load()}
+            className="inline-flex h-9 items-center justify-center rounded-lg border border-border px-3 text-sm hover:bg-muted"
+          >
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {error ? <div className="text-sm text-red-500">{error}</div> : null}
+
+      {loading && !requests.length ? (
+        <div className="text-sm text-muted-foreground">Loading requests...</div>
+      ) : null}
+
+      {!loading && !requests.length ? (
+        <div className="text-sm text-muted-foreground">No requests found.</div>
+      ) : null}
+
+      {requests.length ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {requests.map((req) => (
+            <Link
+              key={req.id}
+              href={`/modules/module-requests/${req.id}`}
+              className="rounded-xl border border-border bg-card p-4 hover:bg-muted/40"
+            >
+              <div className="flex items-start justify-between gap-2">
+                <div>
+                  <div className="text-sm font-semibold">{req.title}</div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {req.module_id}
+                  </div>
+                </div>
+                <div className="text-xs text-muted-foreground">{req.status}</div>
+              </div>
+
+              <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+                <span>
+                  Votes: {req.votes_count} / {req.promotion_threshold}
+                </span>
+                <span>{new Date(req.created_at).toLocaleDateString()}</span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/modules/module-requests/ModuleRequestsModule.tsx
+++ b/src/modules/module-requests/ModuleRequestsModule.tsx
@@ -1,0 +1,452 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { supabaseBrowserClient } from "@/lib/supabase/client";
+
+type ModuleRequest = {
+  id: string;
+  module_id: string;
+  title: string;
+  owner_contact: string | null;
+  status: string;
+  votes_count: number;
+  promotion_threshold: number;
+  github_issue_url: string | null;
+  created_at: string;
+  created_by: string;
+  spec: Record<string, unknown>;
+};
+
+type ListResponse = { items: ModuleRequest[] };
+
+type DetailResponse = { item: ModuleRequest; hasVoted: boolean };
+
+type Tab = "new" | "trending" | "ready" | "mine";
+
+async function authedFetch<T>(
+  token: string,
+  input: RequestInfo,
+  init?: RequestInit,
+): Promise<T> {
+  const res = await fetch(input, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers ?? {}),
+      authorization: `Bearer ${token}`,
+    },
+  });
+
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) {
+    const message = json?.error ?? `Request failed (${res.status})`;
+    throw new Error(message);
+  }
+  return json as T;
+}
+
+export function ModuleRequestsModule() {
+  const supabase = useMemo(() => supabaseBrowserClient(), []);
+
+  const [token, setToken] = useState<string | null>(null);
+  const [tab, setTab] = useState<Tab>("new");
+  const [items, setItems] = useState<ModuleRequest[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [selected, setSelected] = useState<DetailResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const [createForm, setCreateForm] = useState({
+    module_id: "",
+    title: "",
+    owner_contact: "",
+    problem: "",
+    scope: "",
+    ux: "",
+    testing: "",
+  });
+
+  useEffect(() => {
+    (async () => {
+      const { data } = await supabase.auth.getSession();
+      setToken(data.session?.access_token ?? null);
+    })();
+
+    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+      setToken(session?.access_token ?? null);
+    });
+
+    return () => {
+      sub.subscription.unsubscribe();
+    };
+  }, [supabase]);
+
+  async function loadList(nextTab = tab) {
+    if (!token) return;
+    setError(null);
+
+    const params = new URLSearchParams();
+    if (nextTab === "mine") {
+      params.set("status", "mine");
+      params.set("sort", "new");
+    } else {
+      params.set("sort", nextTab);
+      if (nextTab === "ready") params.set("status", "ready");
+    }
+
+    const data = await authedFetch<ListResponse>(
+      token,
+      `/api/modules/module-requests?${params.toString()}`,
+    );
+    setItems(data.items);
+  }
+
+  async function loadDetail(id: string) {
+    if (!token) return;
+    setError(null);
+    const data = await authedFetch<DetailResponse>(
+      token,
+      `/api/modules/module-requests/${id}`,
+    );
+    setSelected(data);
+  }
+
+  useEffect(() => {
+    void loadList();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token, tab]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setSelected(null);
+      return;
+    }
+    void loadDetail(selectedId);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedId, token]);
+
+  async function createDraft() {
+    if (!token) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const spec = {
+        module_id: createForm.module_id.trim(),
+        owner: createForm.owner_contact.trim(),
+        problem: createForm.problem.trim(),
+        scope: createForm.scope.trim(),
+        ux: createForm.ux.trim(),
+        testing: createForm.testing.trim(),
+      };
+
+      await authedFetch<{ item: ModuleRequest }>(token, "/api/modules/module-requests", {
+        method: "POST",
+        body: JSON.stringify({
+          module_id: createForm.module_id,
+          title: createForm.title,
+          owner_contact: createForm.owner_contact,
+          spec,
+        }),
+      });
+
+      setCreateForm({
+        module_id: "",
+        title: "",
+        owner_contact: "",
+        problem: "",
+        scope: "",
+        ux: "",
+        testing: "",
+      });
+
+      await loadList(tab);
+      setTab("mine");
+      await loadList("mine");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to create request.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function publishSelected() {
+    if (!token || !selected?.item) return;
+    setBusy(true);
+    setError(null);
+    try {
+      await authedFetch(token, `/api/modules/module-requests/${selected.item.id}/publish`, {
+        method: "POST",
+      });
+      await loadDetail(selected.item.id);
+      await loadList(tab);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to publish.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function toggleVote() {
+    if (!token || !selected?.item) return;
+    setBusy(true);
+    setError(null);
+    try {
+      if (selected.hasVoted) {
+        await authedFetch(token, `/api/modules/module-requests/${selected.item.id}/vote`, {
+          method: "DELETE",
+        });
+      } else {
+        await authedFetch(token, `/api/modules/module-requests/${selected.item.id}/vote`, {
+          method: "POST",
+        });
+      }
+
+      await loadDetail(selected.item.id);
+      await loadList(tab);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to vote.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function promoteToGithub() {
+    if (!token || !selected?.item) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const data = await authedFetch<{ markdown: string }>(
+        token,
+        `/api/modules/module-requests/${selected.item.id}/promote`,
+        { method: "POST", body: JSON.stringify({}) },
+      );
+
+      await navigator.clipboard.writeText(data.markdown);
+      alert("Copied GitHub issue markdown to clipboard.");
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to promote.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!token) {
+    return (
+      <div className="mx-auto max-w-4xl space-y-4 p-6">
+        <h1 className="text-3xl font-semibold">Module Requests</h1>
+        <p className="text-sm text-muted-foreground">Sign in to create and vote on requests.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-6xl space-y-6 p-6">
+      <div className="space-y-2">
+        <h1 className="text-3xl font-semibold">Module Requests</h1>
+        <p className="text-sm text-muted-foreground">
+          Propose new portal modules and signal interest. When votes hit the threshold, requests become
+          ready for GitHub.
+        </p>
+      </div>
+
+      {error ? <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm">{error}</div> : null}
+
+      <div className="grid gap-6 lg:grid-cols-3">
+        <div className="space-y-4 lg:col-span-2">
+          <div className="flex flex-wrap gap-2">
+            {(
+              [
+                ["new", "New"],
+                ["trending", "Trending"],
+                ["ready", "Ready"],
+                ["mine", "Mine"],
+              ] as const
+            ).map(([key, label]) => (
+              <button
+                key={key}
+                className={`rounded-lg border px-3 py-1.5 text-sm ${
+                  tab === key ? "border-foreground" : "border-border hover:bg-muted"
+                }`}
+                onClick={() => {
+                  setTab(key);
+                  setSelectedId(null);
+                }}
+                disabled={busy}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+
+          <div className="space-y-2">
+            {items.length === 0 ? (
+              <div className="rounded-xl border border-border p-4 text-sm text-muted-foreground">
+                No requests yet.
+              </div>
+            ) : (
+              items.map((item) => (
+                <button
+                  key={item.id}
+                  className={`w-full rounded-xl border p-4 text-left hover:bg-muted ${
+                    selectedId === item.id ? "border-foreground" : "border-border"
+                  }`}
+                  onClick={() => setSelectedId(item.id)}
+                >
+                  <div className="flex items-start justify-between gap-4">
+                    <div className="space-y-1">
+                      <div className="text-base font-medium">{item.title}</div>
+                      <div className="text-xs text-muted-foreground">{item.module_id}</div>
+                      <div className="text-xs text-muted-foreground">Status: {item.status}</div>
+                    </div>
+                    <div className="text-right text-sm">
+                      <div className="font-medium">{item.votes_count}</div>
+                      <div className="text-xs text-muted-foreground">votes</div>
+                    </div>
+                  </div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="rounded-xl border border-border p-4">
+            <div className="mb-3 text-sm font-medium">Create request (draft)</div>
+            <div className="space-y-3">
+              <label className="block">
+                <div className="mb-1 text-xs text-muted-foreground">Title</div>
+                <input
+                  className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                  value={createForm.title}
+                  onChange={(e) => setCreateForm((s) => ({ ...s, title: e.target.value }))}
+                />
+              </label>
+
+              <label className="block">
+                <div className="mb-1 text-xs text-muted-foreground">Module ID (kebab-case)</div>
+                <input
+                  className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                  value={createForm.module_id}
+                  onChange={(e) => setCreateForm((s) => ({ ...s, module_id: e.target.value }))}
+                />
+              </label>
+
+              <label className="block">
+                <div className="mb-1 text-xs text-muted-foreground">Owner / contact</div>
+                <input
+                  className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                  value={createForm.owner_contact}
+                  onChange={(e) => setCreateForm((s) => ({ ...s, owner_contact: e.target.value }))}
+                />
+              </label>
+
+              <label className="block">
+                <div className="mb-1 text-xs text-muted-foreground">Problem</div>
+                <textarea
+                  className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                  rows={3}
+                  value={createForm.problem}
+                  onChange={(e) => setCreateForm((s) => ({ ...s, problem: e.target.value }))}
+                />
+              </label>
+
+              <label className="block">
+                <div className="mb-1 text-xs text-muted-foreground">Scope</div>
+                <textarea
+                  className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                  rows={3}
+                  value={createForm.scope}
+                  onChange={(e) => setCreateForm((s) => ({ ...s, scope: e.target.value }))}
+                />
+              </label>
+
+              <label className="block">
+                <div className="mb-1 text-xs text-muted-foreground">UX</div>
+                <textarea
+                  className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                  rows={3}
+                  value={createForm.ux}
+                  onChange={(e) => setCreateForm((s) => ({ ...s, ux: e.target.value }))}
+                />
+              </label>
+
+              <label className="block">
+                <div className="mb-1 text-xs text-muted-foreground">Testing (optional)</div>
+                <textarea
+                  className="w-full rounded-lg border border-border bg-background px-3 py-2 text-sm"
+                  rows={2}
+                  value={createForm.testing}
+                  onChange={(e) => setCreateForm((s) => ({ ...s, testing: e.target.value }))}
+                />
+              </label>
+
+              <button
+                className="w-full rounded-lg bg-foreground px-3 py-2 text-sm text-background disabled:opacity-50"
+                disabled={busy || !createForm.title.trim() || !createForm.module_id.trim()}
+                onClick={() => void createDraft()}
+              >
+                {busy ? "Working…" : "Create draft"}
+              </button>
+            </div>
+          </div>
+
+          {selected ? (
+            <div className="rounded-xl border border-border p-4">
+              <div className="space-y-2">
+                <div className="text-sm font-medium">Selected</div>
+                <div className="text-base font-semibold">{selected.item.title}</div>
+                <div className="text-xs text-muted-foreground">{selected.item.module_id}</div>
+                <div className="text-xs text-muted-foreground">Status: {selected.item.status}</div>
+                <div className="text-xs text-muted-foreground">
+                  Votes: {selected.item.votes_count} / {selected.item.promotion_threshold}
+                </div>
+
+                {selected.item.github_issue_url ? (
+                  <a
+                    href={selected.item.github_issue_url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="text-sm underline"
+                  >
+                    GitHub issue
+                  </a>
+                ) : null}
+
+                <div className="flex flex-wrap gap-2 pt-2">
+                  <button
+                    className="rounded-lg border border-border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+                    disabled={busy || !new Set(["open", "ready"]).has(selected.item.status)}
+                    onClick={() => void toggleVote()}
+                  >
+                    {selected.hasVoted ? "Unvote" : "Vote"}
+                  </button>
+
+                  <button
+                    className="rounded-lg border border-border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+                    disabled={busy || selected.item.status !== "draft"}
+                    onClick={() => void publishSelected()}
+                  >
+                    Publish
+                  </button>
+
+                  <button
+                    className="rounded-lg border border-border px-3 py-1.5 text-sm hover:bg-muted disabled:opacity-50"
+                    disabled={busy || selected.item.status !== "ready"}
+                    onClick={() => void promoteToGithub()}
+                    title="Host-only; copies markdown"
+                  >
+                    Promote (copy markdown)
+                  </button>
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="rounded-xl border border-border p-4 text-sm text-muted-foreground">
+              Select a request to view details.
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/modules/module-requests/types.ts
+++ b/src/modules/module-requests/types.ts
@@ -1,0 +1,22 @@
+export type ModuleRequestStatus =
+  | "draft"
+  | "open"
+  | "ready"
+  | "submitted_to_github"
+  | "archived";
+
+export type ModuleRequest = {
+  id: string;
+  created_by: string;
+  module_id: string;
+  title: string;
+  owner_contact: string | null;
+  status: ModuleRequestStatus;
+  spec: Record<string, unknown>;
+  votes_count: number;
+  promotion_threshold: number;
+  github_issue_url: string | null;
+  submitted_to_github_at: string | null;
+  created_at: string;
+  updated_at: string;
+};

--- a/supabase/migrations/0018_module_requests.sql
+++ b/supabase/migrations/0018_module_requests.sql
@@ -1,0 +1,161 @@
+-- Module Requests (idea intake + voting)
+
+create table if not exists public.module_requests (
+  id uuid primary key default gen_random_uuid(),
+  created_by uuid not null references auth.users (id) on delete cascade,
+  module_id text not null,
+  title text not null,
+  owner_contact text null,
+  status text not null default 'draft',
+  spec jsonb not null default '{}'::jsonb,
+  votes_count int4 not null default 0,
+  promotion_threshold int4 not null default 10,
+  github_issue_url text null,
+  submitted_to_github_at timestamptz null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  deleted_at timestamptz null,
+  constraint module_requests_status_allowed check (
+    status in ('draft', 'open', 'ready', 'submitted_to_github', 'archived')
+  )
+);
+
+create index if not exists idx_module_requests_status_updated_at
+  on public.module_requests (status, updated_at desc);
+
+create index if not exists idx_module_requests_created_by_created_at
+  on public.module_requests (created_by, created_at desc);
+
+create table if not exists public.module_request_votes (
+  request_id uuid not null references public.module_requests (id) on delete cascade,
+  user_id uuid not null references auth.users (id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (request_id, user_id)
+);
+
+create index if not exists idx_module_request_votes_request_id
+  on public.module_request_votes (request_id);
+
+create index if not exists idx_module_request_votes_user_id
+  on public.module_request_votes (user_id);
+
+drop trigger if exists set_module_requests_updated_at on public.module_requests;
+create trigger set_module_requests_updated_at
+before update on public.module_requests
+for each row execute function public.set_updated_at();
+
+-- Keep module_requests.votes_count in sync.
+create or replace function public.module_requests_update_votes_count()
+returns trigger
+language plpgsql
+security definer
+as $$
+declare
+  target_request_id uuid;
+  new_count int4;
+  threshold int4;
+  current_status text;
+begin
+  target_request_id := coalesce(new.request_id, old.request_id);
+
+  select count(*)::int4 into new_count
+  from public.module_request_votes v
+  where v.request_id = target_request_id;
+
+  update public.module_requests r
+    set votes_count = new_count
+  where r.id = target_request_id;
+
+  -- Auto-promote open requests to ready when threshold reached.
+  select r.promotion_threshold, r.status
+    into threshold, current_status
+  from public.module_requests r
+  where r.id = target_request_id;
+
+  if current_status = 'open' and new_count >= threshold then
+    update public.module_requests
+      set status = 'ready'
+    where id = target_request_id;
+  end if;
+
+  return null;
+end;
+$$;
+
+drop trigger if exists trg_module_requests_votes_count_insert on public.module_request_votes;
+drop trigger if exists trg_module_requests_votes_count_delete on public.module_request_votes;
+
+create trigger trg_module_requests_votes_count_insert
+after insert on public.module_request_votes
+for each row execute function public.module_requests_update_votes_count();
+
+create trigger trg_module_requests_votes_count_delete
+after delete on public.module_request_votes
+for each row execute function public.module_requests_update_votes_count();
+
+alter table public.module_requests enable row level security;
+alter table public.module_request_votes enable row level security;
+
+-- Reads
+create policy "Authenticated users can view open/ready module requests"
+on public.module_requests
+for select
+to authenticated
+using (
+  deleted_at is null
+  and status in ('open', 'ready')
+);
+
+create policy "Creators can view their own module requests"
+on public.module_requests
+for select
+to authenticated
+using (
+  deleted_at is null
+  and created_by = auth.uid()
+);
+
+-- Writes
+create policy "Authenticated users can create module requests"
+on public.module_requests
+for insert
+to authenticated
+with check (created_by = auth.uid());
+
+create policy "Creators can update their draft module requests"
+on public.module_requests
+for update
+to authenticated
+using (created_by = auth.uid() and status = 'draft' and deleted_at is null)
+with check (created_by = auth.uid() and deleted_at is null);
+
+-- Votes
+create policy "Authenticated users can view votes"
+on public.module_request_votes
+for select
+to authenticated
+using (true);
+
+create policy "Authenticated users can vote on open/ready requests"
+on public.module_request_votes
+for insert
+to authenticated
+with check (
+  user_id = auth.uid()
+  and exists (
+    select 1
+    from public.module_requests r
+    where r.id = request_id
+      and r.deleted_at is null
+      and r.status in ('open', 'ready')
+  )
+);
+
+create policy "Authenticated users can unvote their vote"
+on public.module_request_votes
+for delete
+to authenticated
+using (user_id = auth.uid());
+
+-- Note: host/admin promotion and archived/submitted transitions should happen via
+-- Next.js API routes using the Supabase service role.

--- a/supabase/seeds/staging/0004_module_requests_fixtures.sql
+++ b/supabase/seeds/staging/0004_module_requests_fixtures.sql
@@ -1,0 +1,114 @@
+-- Staging fixtures: Module Requests
+-- Idempotent upserts with deterministic UUIDs.
+
+-- Personas from 0002_people_fixtures.sql
+--  - staging-host:         aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa
+--  - staging-contributor:  bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb
+--  - staging-admin:        cccccccc-cccc-cccc-cccc-cccccccccccc
+
+-- Requests
+insert into public.module_requests (
+  id,
+  created_by,
+  module_id,
+  title,
+  owner_contact,
+  status,
+  spec,
+  promotion_threshold,
+  github_issue_url,
+  submitted_to_github_at,
+  created_at,
+  updated_at,
+  deleted_at
+) values
+(
+  '11111111-1111-1111-1111-111111111111',
+  'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+  'skill-swap',
+  'Skill Swap',
+  'discord:@staging_contributor',
+  'open',
+  jsonb_build_object(
+    'module_id','skill-swap',
+    'owner','discord:@staging_contributor',
+    'problem','Members want a lightweight way to swap skills.',
+    'scope','MVP: offers + requests',
+    'ux','List + detail + create form',
+    'testing','Manual smoke test'
+  ),
+  10,
+  null,
+  null,
+  now() - interval '4 days',
+  now() - interval '4 days',
+  null
+),
+(
+  '22222222-2222-2222-2222-222222222222',
+  'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+  'project-kudos',
+  'Project Kudos',
+  'discord:@staging_contributor',
+  'open',
+  jsonb_build_object(
+    'module_id','project-kudos',
+    'owner','discord:@staging_contributor',
+    'problem','Recognize shipped work with quick kudos.',
+    'scope','MVP: kudos posts',
+    'ux','Cards + reactions later',
+    'testing','Manual smoke test'
+  ),
+  10,
+  null,
+  null,
+  now() - interval '2 days',
+  now() - interval '2 days',
+  null
+),
+(
+  '33333333-3333-3333-3333-333333333333',
+  'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+  'module-requests',
+  'Module Requests',
+  'discord:@portal',
+  'ready',
+  jsonb_build_object(
+    'module_id','module-requests',
+    'owner','discord:@portal',
+    'problem','A front door for module ideas.',
+    'scope','MVP: create + vote + promote',
+    'ux','New/Trending/Ready',
+    'testing','Manual smoke test'
+  ),
+  3,
+  null,
+  null,
+  now() - interval '1 day',
+  now() - interval '1 day',
+  null
+)
+on conflict (id) do update set
+  created_by = excluded.created_by,
+  module_id = excluded.module_id,
+  title = excluded.title,
+  owner_contact = excluded.owner_contact,
+  status = excluded.status,
+  spec = excluded.spec,
+  promotion_threshold = excluded.promotion_threshold,
+  github_issue_url = excluded.github_issue_url,
+  submitted_to_github_at = excluded.submitted_to_github_at,
+  updated_at = excluded.updated_at,
+  deleted_at = excluded.deleted_at;
+
+-- Votes (composite PK)
+insert into public.module_request_votes (request_id, user_id, created_at) values
+  -- 2 votes on an open request
+  ('22222222-2222-2222-2222-222222222222', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now() - interval '2 days'),
+  ('22222222-2222-2222-2222-222222222222', 'cccccccc-cccc-cccc-cccc-cccccccccccc', now() - interval '2 days'),
+
+  -- 3 votes (threshold=3) on a ready request
+  ('33333333-3333-3333-3333-333333333333', 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa', now() - interval '1 day'),
+  ('33333333-3333-3333-3333-333333333333', 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb', now() - interval '1 day'),
+  ('33333333-3333-3333-3333-333333333333', 'cccccccc-cccc-cccc-cccc-cccccccccccc', now() - interval '1 day')
+on conflict (request_id, user_id) do nothing;


### PR DESCRIPTION
$Fixes #34

Implements the Module Requests module (idea intake + voting + GitHub promotion flow).

## Manual test plan (staging)

Areas touched:
- Module registry (Module Requests entry)
- Supabase DB: `module_requests` + `module_request_votes` tables, RLS, triggers
- Next.js module UI: /modules/module-requests
- Next.js API routes: /api/modules/module-requests/*
- Staging seeds: `supabase/seeds/staging/0004_module_requests_fixtures.sql`

Test accounts:
- staging-contributor (normal user)
- staging-host (host)

Steps:
1) Sign in as staging-contributor, open /me → Module Requests
2) Create a request draft (fill required fields) and save
3) Publish draft → verify status becomes open
4) As another authenticated user, vote and unvote → verify votes_count updates and duplicate votes are blocked
5) Vote until threshold reached (or use seeded ready request) → verify status becomes ready
6) Sign in as staging-host → open a ready request → click Promote → verify GitHub-ready markdown is generated and GitHub URL can be stored (status → submitted_to_github)

Expected results:
- Unauthenticated users cannot access list/detail APIs
- Only creators can edit drafts; publish works for creator
- One vote per user enforced (409 on double vote)
- votes_count stays in sync and ready status is reached at threshold
- Host-only promotion endpoint is forbidden for non-host


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Module Requests system enabling users to propose new modules through a draft-and-publish workflow
  * Added voting functionality to gauge community interest in proposed modules
  * Integrated GitHub integration to promote approved requests as GitHub issues
  * Created browsable module request catalog organized by status (new, trending, ready, archived)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->