### PR TITLE
add a smaller default /me module set

### DIFF
--- a/src/lib/module-views.ts
+++ b/src/lib/module-views.ts
@@ -34,7 +34,9 @@ export function getSurfaceViewConfig(
 
   if (!hasStoredSurface) {
     const defaultVisible = DEFAULT_VISIBLE_MODULES_BY_SURFACE[surface] ?? moduleIds;
-    const defaultVisibleSet = new Set(defaultVisible.filter((id) => knownIds.has(id)));
+    const intersection = defaultVisible.filter((id) => knownIds.has(id));
+    // If defaults drift from registry/moduleIds, avoid hiding every module.
+    const defaultVisibleSet = new Set(intersection.length > 0 ? intersection : moduleIds);
     normalizedHidden = moduleIds.filter((id) => !defaultVisibleSet.has(id));
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved module visibility handling with intelligent defaults. The app now determines which modules display by default based on your surface type, while preserving any custom configurations you've already set up.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->