### PR TITLE
Add Cohort DM Guide module registry entry

### DIFF
--- a/modules/registry.json
+++ b/modules/registry.json
@@ -713,6 +713,55 @@
       }
     },
     {
+      "id": "cohort-dm-guide",
+      "title": "Cohort DM Guide",
+      "description": "Open facilitation docs, templates, and escalation playbooks in one place.",
+      "lane": "hosts",
+      "type": "link",
+      "url": "https://cohort-dm-guide.vercel.app",
+      "status": "live",
+      "owner": {
+        "name": "@dekanbro",
+        "contact": "@dekanbro"
+      },
+      "requiresAuth": true,
+      "tags": [
+        "hosts",
+        "host-tools"
+      ],
+      "presentation": {
+        "mode": "dialog",
+        "trigger": "button",
+        "dialog": {
+          "size": "lg"
+        },
+        "iframe": {
+          "height": 820
+        }
+      },
+      "summary": {
+        "source": "static",
+        "title": "Cohort DM Guide",
+        "items": [
+          {
+            "label": "Facilitation checklists",
+            "value": "Run each session with a consistent host playbook."
+          },
+          {
+            "label": "Session templates",
+            "value": "Reuse ready-made templates for cohort operations."
+          },
+          {
+            "label": "Escalation playbooks",
+            "value": "Reference next steps for blockers and support paths."
+          }
+        ],
+        "layout": "list",
+        "maxItems": 3,
+        "showTitle": true
+      }
+    },
+    {
       "id": "module-requests",
       "title": "Module Requests",
       "description": "Propose new portal modules and signal interest.",


### PR DESCRIPTION
## Summary
- add `cohort-dm-guide` as a host-only module in `modules/registry.json`
- configure module as an external dialog link to `https://cohort-dm-guide.vercel.app`
- set iframe presentation height to `820` and include static summary items for host context

## Validation
- npm run lint

Fixes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Cohort DM Guide module to the registry, providing users with organized guidance content in an accessible dialog interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->